### PR TITLE
Allow kwargs for set_color

### DIFF
--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -123,9 +123,8 @@ class LIFX:
         """
         if all_lights:
             selector = 'all'
-        path = LIFX_URL+selector+'/toggle'
         data = {'duration':duration}
-        return self._post(path, data)
+        return self._post(LIFX_URL+selector+'/toggle', data)
 
     def move_effect(self, selector, move_direction, period, power_on):
         """Performs a linear move effect on a light, or lights.
@@ -133,43 +132,32 @@ class LIFX:
         :param double period: Time in second per effect cycle.
         :param bool power_on: Turn on a light before performing the move.
         """
-        path = LIFX_URL+selector+'/effects/move'
         data = {'direction':move_direction,
                 'period':period,
                 'power_on':power_on}
-        return self._post(path, data)
+        return self._post(LIFX_URL+selector+'/effects/move', data)
 
     def effects_off(self, selector, power_off=False):
         """Turns off any running effects on the selected device.
         :param dict selector: Selector to control which lights are requested.
         :param bool power_off: If true, the devices will also be turned off.
         """
-        path = LIFX_URL+selector+'/effects/off'
         data = {'power_off', power_off}
-        return self._post(path, data)
+        return self._post(LIFX_URL+selector+'/effects/off', data)
 
     def set_brightness(self, selector, brightness):
         """Sets the state of the lights within the selector.
         :param dict selector: Selector to control which lights are requested.
         :param double brightness: Brightness level of the light, from 0.0 to 1.0.
         """
-        path = LIFX_URL+selector+'/state'
         data = {'brightness':brightness}
-        return self._put(path, data)
+        return self._put(LIFX_URL+selector+'/state', data)
 
-    def set_color(self, selector, power, color, brightness=1.0):
+    def set_color(self, selector, **kwargs):
         """Sets the state of the light's color within the selector.
-        :param dict selector: Selector to control which lights are requested.
-        :param str power: Sets the power state of the light (on/off).
-        :param str color: Color to set the light to (https://api.developer.lifx.com/v1/docs/colors).
-        :param double brightness: Brightness level of the light from 0.0 to 1.0.
+        Valid arguments: https://api.developer.lifx.com/v1/docs/colors
         """
-        path = LIFX_URL+selector+'/state'
-        data = {'power':power,
-                'color':color,
-                'brightness':brightness
-               }
-        return self._put(path, data)
+        return self._put(LIFX_URL+selector+'/state', kwargs)
 
     def list_lights(self):
         """Enumerates all the lights associated with the LIFX Cloud Account

--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -155,7 +155,7 @@ class LIFX:
 
     def set_color(self, selector, **kwargs):
         """Sets the state of the light's color within the selector.
-        Valid arguments: https://api.developer.lifx.com/v1/docs/colors
+        Valid arguments: https://api.developer.lifx.com/docs/set-state
         """
         return self._put(LIFX_URL+selector+'/state', kwargs)
 

--- a/examples/lifx_simpletest.py
+++ b/examples/lifx_simpletest.py
@@ -49,7 +49,7 @@ lifx.set_brightness(lifx_light, light_brightness)
 colors = ['yellow', 'blue', 'white']
 for color in colors:
     print('Setting light to: ', color)
-    lifx.set_color(lifx_light, 'on', color, brightness=light_brightness)
+    lifx.set_color(lifx_light, power='on', color=color, brightness=light_brightness)
 
 # Turn off the light
 print('Turning off light...')


### PR DESCRIPTION
Modifying `set_color` to take in kwargs instead of predefined arguments. This allows actions such as setting the color, but not modifying (or providing) a brightness or state. 

Removing lines containing redefinitions of path in favor of including the path directly in the HTTP request