### PR TITLE
Add support for adafruit_requests.Session

### DIFF
--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -21,6 +21,12 @@ Implementation Notes
 * Adafruit ESP32SPI or ESP_ATcontrol library:
     https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI
     https://github.com/adafruit/Adafruit_CircuitPython_ESP_ATcontrol
+
+or:
+
+* Adafruit_requests library:
+   https://github.com/adafruit/Adafruit_CircuitPython_Requests
+
 """
 
 __version__ = "0.0.0-auto.0"
@@ -38,10 +44,12 @@ class LIFX:
         """
         Creates an instance of the LIFX HTTP API client.
         :param wifi_manager wifi_manager: WiFiManager from ESPSPI_WiFiManager/ESPAT_WiFiManager
+        or session from adafruit_requests.Session
         :param str lifx_token: LIFX API token (https://api.developer.lifx.com/docs/authentication)
         """
         wifi_type = str(type(wifi_manager))
-        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" in wifi_type or "Session" in wifi_type:
+        allowed_wifi_types = ("ESPSPI_WiFiManager", "ESPAT_WiFiManager", "Session")
+        if any(x in wifi_type for x in allowed_wifi_types):
             self._wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager or Session object.")

--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -41,7 +41,7 @@ class LIFX:
         :param str lifx_token: LIFX API token (https://api.developer.lifx.com/docs/authentication)
         """
         wifi_type = str(type(wifi_manager))
-        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" or "Session" in wifi_type:
+        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" in wifi_type or "Session" in wifi_type:
             self._wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager or Session object.")

--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -41,10 +41,10 @@ class LIFX:
         :param str lifx_token: LIFX API token (https://api.developer.lifx.com/docs/authentication)
         """
         wifi_type = str(type(wifi_manager))
-        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" in wifi_type:
+        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" or Session in wifi_type:
             self._wifi = wifi_manager
         else:
-            raise TypeError("This library requires a WiFiManager object.")
+            raise TypeError("This library requires a WiFiManager or Session object.")
         self._lifx_token = lifx_token
         self._auth_header = {
             "Authorization": "Bearer %s" % self._lifx_token,

--- a/adafruit_lifx.py
+++ b/adafruit_lifx.py
@@ -41,7 +41,7 @@ class LIFX:
         :param str lifx_token: LIFX API token (https://api.developer.lifx.com/docs/authentication)
         """
         wifi_type = str(type(wifi_manager))
-        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" or Session in wifi_type:
+        if "ESPSPI_WiFiManager" in wifi_type or "ESPAT_WiFiManager" or "Session" in wifi_type:
             self._wifi = wifi_manager
         else:
             raise TypeError("This library requires a WiFiManager or Session object.")

--- a/examples/lifx_simpletest_esp32s2.py
+++ b/examples/lifx_simpletest_esp32s2.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import board
+import busio
+from digitalio import DigitalInOut
+import wifi
+import socketpool
+import ssl
+import adafruit_requests
+import neopixel
+
+import adafruit_lifx
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi and API secrets are kept in secrets.py, please add them there!")
+    raise
+
+# Set up ESP32-S2 and adafruit_requests session
+wifi.radio.connect(ssid=secrets['ssid'],password=secrets['password'])
+pool = socketpool.SocketPool(wifi.radio)
+http_session = adafruit_requests.Session(pool, ssl.create_default_context())
+
+# Add your LIFX Personal Access token to secrets.py
+# (to obtain a token, visit: https://cloud.lifx.com/settings)
+lifx_token = secrets["lifx_token"]
+
+# Set this to your LIFX light separator label
+# https://api.developer.lifx.com/docs/selectors
+lifx_light = "label:Lamp"
+
+# Initialize the LIFX API Client
+lifx = adafruit_lifx.LIFX(http_session, lifx_token)
+
+# List all lights
+lights = lifx.list_lights()
+
+# Turn on the light
+print("Turning on light...")
+lifx.toggle_light(lifx_light)
+
+# Set the light's brightness to 50%
+light_brightness = 0.5
+lifx.set_brightness(lifx_light, light_brightness)
+
+# Cycle the light using the colors of the Python logo
+colors = ["yellow", "blue", "white"]
+for color in colors:
+    print("Setting light to: ", color)
+    lifx.set_color(lifx_light, power="on", color=color, brightness=light_brightness)
+
+# Turn off the light
+print("Turning off light...")
+lifx.toggle_light(lifx_light)

--- a/examples/lifx_simpletest_esp32s2.py
+++ b/examples/lifx_simpletest_esp32s2.py
@@ -20,7 +20,7 @@ except ImportError:
     raise
 
 # Set up ESP32-S2 and adafruit_requests session
-wifi.radio.connect(ssid=secrets['ssid'],password=secrets['password'])
+wifi.radio.connect(ssid=secrets["ssid"], password=secrets["password"])
 pool = socketpool.SocketPool(wifi.radio)
 http_session = adafruit_requests.Session(pool, ssl.create_default_context())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 Adafruit_CircuitPython_ESP32SPI
+adafruit_circuitpython_requests


### PR DESCRIPTION
Currently `adafruit_lifx` supports older `adafruit_esp32spi_wifimanager`.  This PR adds support for `adafruit_requests.Session`